### PR TITLE
readability/documentation tweaks

### DIFF
--- a/R/escape.R
+++ b/R/escape.R
@@ -6,7 +6,7 @@
 #' @export
 #' @name utility functions
 #' @rdname utilities
-#' @param url a string (typically a url or parameter) to be URL encoded
+#' @param url a string (typically a url or parameter) to be URL encoded or decoded
 #' @examples # Escape strings
 #' out <- curl_escape("foo = bar + 5")
 #' curl_unescape(out)

--- a/R/form.R
+++ b/R/form.R
@@ -5,7 +5,7 @@
 #' @export
 form_file <- function(path, type = NULL){
   path <- normalizePath(path[1], mustWork = TRUE)
-  if(length(type)){
+  if(!is.null(type)){
     stopifnot(is.character(type))
   }
   out <- list(path = path, type = type)
@@ -16,7 +16,7 @@ form_file <- function(path, type = NULL){
 #' @export
 print.form_file <- function(x, ...){
   txt <- paste("Form file:", basename(x$path))
-  if(length(x$type)){
+  if(!is.null(x$type)){
     txt <- paste0(txt, " (", x$type, ")")
   }
   cat(txt, "\n")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -17,7 +17,7 @@ curl_options <- function(){
 }
 
 #' @rdname utilities
-#' @param datestring a string with a timestamp
+#' @param datestring a string consisting of a timestamp
 #' @useDynLib curl R_curl_getdate
 #' @export
 #' @examples

--- a/man/utilities.Rd
+++ b/man/utilities.Rd
@@ -20,9 +20,9 @@ curl_options()
 curl_getdate(datestring)
 }
 \arguments{
-\item{url}{a string (typically a url or parameter) to be URL encoded}
+\item{url}{a string (typically a url or parameter) to be URL encoded or decoded}
 
-\item{datestring}{a string with a timestamp}
+\item{datestring}{a string consisting of a timestamp}
 }
 \description{
 Utility functions for working with curl.


### PR DESCRIPTION
This:

1. Expands on the documentation slightly to note the decoding as well as encoding usage of "url" as a field in utilities functions;
2. Tweaks "string with a timestamp" to "string consisting of a timestamp" ("with a timestamp" implies you can have anything else there. curl_getdate("flibbertigibett, 06-Nov-94 08:49:37 GMT") doesn't work)
3. Replaces length(foo) calls, which are being used to test if foo is NULL, with a direct !is.null(), for improved code readability (you don't need to know length(NULL) == 0 to work out what the code does any more. Which is a good thing, because I long ago stopped expecting evaluations to do the rational thing when I threw a NULL at them)