### PR TITLE
Tell me which options are invalid

### DIFF
--- a/R/handle.R
+++ b/R/handle.R
@@ -54,9 +54,12 @@ new_handle <- function(...){
 #' @rdname handle
 handle_setopt <- function(handle, ..., .list = list()){
   values <- c(list(...), .list)
-  keys <- as.integer(curl_options()[tolower(names(values))])
+  opt_names <- tolower(names(values))
+  keys <- as.integer(curl_options()[opt_names])
   if(anyNA(keys)){
-    stop("Unknown options.")
+    bad_opts <- opt_names[is.na(keys)]
+    stop("Unknown option", ifelse(length(bad_opts) > 1, "s: ", ": "),
+      paste(bad_opts, collapse=", "))
   }
   stopifnot(length(keys) == length(values))
   .Call(R_handle_setopt, handle, keys, values)

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -80,3 +80,15 @@ test_that("Downloading to a file", {
   expect_equal(jsonlite::fromJSON(tmp)$cookies$foo, "123")
   suppressWarnings(gc())
 })
+
+test_that("handle_setopt validates options", {
+  h <- new_handle()
+  expect_identical(class(h), "curl_handle")
+  expect_error(handle_setopt(h, invalid.option="foo"),
+    "Unknown option: invalid.option")
+  expect_error(handle_setopt(h, badopt1="foo", badopt2="bar"),
+    "Unknown options: badopt1, badopt2")
+  expect_identical(class(handle_setopt(h, username="foo")),
+    "curl_handle") ## i.e. that's a valid option, so it succeeds
+  suppressWarnings(gc())
+})


### PR DESCRIPTION
A package I maintain (https://github.com/Crunch-io/rcrunch) depends on httr, and in checking it against the pre-release version of httr that depends on curl, I found that the new httr was largely a drop-in replacement, except for a ton of "Unknown options." errors. The error message in `handle_setopt` was not very helpful in debugging, so I modified it to identify the problem option(s). That allowed me to resolve the issues quickly.

The added tests show the validation erroring correctly when there are one or many invalid options, as well as confirming that it succeeds when the option is valid. 