### PR TITLE
Installation fails on OpenBSD due to undefined BSWAP_32

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -25,6 +25,11 @@
 #error "Unsupported connections API version"
 #endif
 
+/* Define BSWAP_32 for OpenBSD */
+#if (defined(__OpenBSD__))
+#define BSWAP_32(x) swap32(x)
+#endif
+
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define R_EOF -1
 


### PR DESCRIPTION
I don't know if I've done this correctly, but this modification seems to result in a working build of the curl package on OpenBSD. BSWAP_32 isn't defined, and is instead called swap32 on OpenBSD. I'm guessing there may be similar issues on FreeBSD and NetBSD as well (see the following for examples of how people have defined BSWAP_32 for those platforms):

https://github.com/jasperla/openbsd-wip/blob/master/x11/tde/k3b/patches/patch-libk3b_core_k3bglobals_cpp

Cheers,
Peter