### PR TITLE
Coerce curl_escape/curl_unescape arguments to character.

### DIFF
--- a/R/escape.R
+++ b/R/escape.R
@@ -16,11 +16,11 @@
 #' curl_escape(mu)
 #' curl_unescape(curl_escape(mu))
 curl_escape <- function(url){
-  .Call(R_curl_escape, url, FALSE);
+  .Call(R_curl_escape, as.character(url), FALSE);
 }
 
 #' @rdname curl_escape
 #' @export
 curl_unescape <- function(url){
-  .Call(R_curl_escape, url, TRUE);
+  .Call(R_curl_escape, as.character(url), TRUE);
 }

--- a/tests/testthat/test-escape.R
+++ b/tests/testthat/test-escape.R
@@ -1,0 +1,22 @@
+context("URL escaping")
+
+test_that("basic encoding", {
+  expect_equal("a%2Fb%2Fc", curl_escape("a/b/c"))
+  expect_equal("a = b + c", curl_unescape("a%20%3D%20b%20%2B%20c"))
+})
+
+test_that("curl_{,un}escape handle NULL", {
+  escaped_null <- curl_escape(NULL)
+  expect_equal(0, length(escaped_null))
+  expect_equal("character", class(escaped_null))
+  unescaped_null <- curl_unescape(NULL)
+  expect_equal(0, length(unescaped_null))
+  expect_equal("character", class(unescaped_null))
+})
+
+test_that("curl_escape and curl_unescape are inverses", {
+  mu <- "\u00b5"
+  expect_equal(mu, curl_unescape(curl_escape(mu)))
+  escaped_mu <- curl_escape(mu)
+  expect_equal(escaped_mu, curl_escape(curl_unescape(escaped_mu)))
+})


### PR DESCRIPTION
This copies the default behavior of `RCurl`, which automatically coerces the
`url` argument to a character. This has the side-effect of fixing `NULL`
handling (see hadley/bigrquery#54 and hadley/httr#259).

If the goal was to explicitly *avoid* coercion (since the functions are
documented as consuming a character vector), I can reduce this to simply do
better `NULL` handling.

PTAL @jeroenooms 