### PR TITLE
Add a test coverage badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ language: r
 warnings_are_errors: true
 #r_check_revdep: true
 
+r_packages:
+  - covr
+
 apt_packages:
   - libcurl4-openssl-dev
+
+after_success:
+  - Rscript -e 'covr::codecov()'
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ A Connection Interface to Libcurl
 ---------------------------------
 
 [![Build Status](https://travis-ci.org/jeroenooms/curl.svg?branch=master)](https://travis-ci.org/jeroenooms/curl)
+[![Coverage Status](https://img.shields.io/codecov/c/github/jeroenooms/curl/master.svg)](https://codecov.io/github/jeroenooms/curl?branch=master)
 
 > The curl() function provides a drop-in replacement for base url()
   with better performance and support for http 2.0, ssl (https://, ftps://),


### PR DESCRIPTION
You will have to enable the curl project on codecov.io for it to work
(you can login with your GitHub credentials)