### PR TITLE
Introduce a default progress callback to catch signals

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,4 +1,12 @@
 #include "curl-common.h"
+#include "utils.h"
+
+int default_callback_progress(void *p, 
+                              double dltotal, double dlnow, 
+                              double ultotal, double ulnow)
+{
+  return !(R_ToplevelExec(check_interrupt_fn, NULL));
+}
 
 int R_curl_callback_progress(SEXP fun,
                              double dltotal, double dlnow,

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,8 +1,8 @@
 #include "curl-common.h"
 #include "utils.h"
 
-int default_callback_progress(void *p, 
-                              double dltotal, double dlnow, 
+int default_callback_progress(void *dummy,
+                              double dltotal, double dlnow,
                               double ultotal, double ulnow)
 {
   return !(R_ToplevelExec(check_interrupt_fn, NULL));

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -3,5 +3,5 @@ int R_curl_callback_progress(SEXP fun, double dltotal, double dlnow,
 size_t R_curl_callback_read(char *buffer, size_t size, size_t nitems, SEXP fun);
 int R_curl_callback_debug(CURL *handle, curl_infotype type_, char *data,
                           size_t size, SEXP fun);
-int default_callback_progress(void *clientp, double dltotal,
+int default_callback_progress(void *dummy, double dltotal,
                               double dlnow, double ultotal, double ulnow);

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -3,3 +3,5 @@ int R_curl_callback_progress(SEXP fun, double dltotal, double dlnow,
 size_t R_curl_callback_read(char *buffer, size_t size, size_t nitems, SEXP fun);
 int R_curl_callback_debug(CURL *handle, curl_infotype type_, char *data,
                           size_t size, SEXP fun);
+int default_callback_progress(void *clientp, double dltotal,
+                              double dlnow, double ultotal, double ulnow);

--- a/src/handle.c
+++ b/src/handle.c
@@ -84,6 +84,12 @@ void set_handle_defaults(reference *ref){
   /* allow all authentication methods */
   assert(curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY));
   assert(curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L));
+
+  /* a default progress callback for signal handling */
+  assert(curl_easy_setopt(handle, CURLOPT_XFERINFOFUNCTION,
+         default_callback_progress));
+  assert(curl_easy_setopt(handle, CURLOPT_XFERINFODATA, NULL));
+  assert(curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 0L));
 }
 
 SEXP R_new_handle(){

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,2 @@
+
+void check_interrupt_fn(void *dummy);


### PR DESCRIPTION
First, thank you for this extremely well-written and useful package.

Unlike the custom R connection `curl` function, the `curl_fetch_*` functions use `curl_easy_perform` without a default progress callback function that can check for interrupts.

One serious consequence, for example, is that almost no `httr` package functions can be interrupted, without manually supplying an R function progress callback and introducing a lot of overhead.

The idea of this PR is to introduce a lightweight default progress function callback that simply calls the existing `check_interrupt_fn` so that all easy_perform transfers are responsive to interrupts. Users remain free to set a custom R progress callback function in the handle, overriding the simple default.

## Example
To see an example, at least on Linux systems with the `nc` program installed, follow this procedure:

1. Open a terminal window and run

    ```
    nc -l 9999
    ```

2. Start R either from the command line or RStudio and run

    ```r
    library(curl)
    curl_fetch_memory("http://localhost:9999")
    
    # or, to equivalent effect,
    library(httr)
    GET("http://localhost:9999")
    ```

Now try to interrupt the download with CTRL+C (command-line R) or by pressing the STOP button or ESC (RStudio). The R process will hang. Fortunately, you can back out of this example gracefully by pressing CTRL+C in the terminal window that `nc` is running in (Step 1.).

Now try installing this fork of the `curl` package and repeat the procedure. You should be able to cancel the download.

## Overhead

I made some anecdotal measurements of data transfer performance with and without the default progress callback and despite the additional `check_interrupt_fn` function calls did not measure any significant difference in throughput.