### PR TITLE
Introduce a default progress callback to catch signals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: r
+sudo: required
 
 warnings_are_errors: true
 #r_check_revdep: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: r
-sudo: required
 
 warnings_are_errors: true
 #r_check_revdep: true

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,4 +1,12 @@
 #include "curl-common.h"
+#include "utils.h"
+
+int default_callback_progress(void *p, 
+                              double dltotal, double dlnow, 
+                              double ultotal, double ulnow)
+{
+  return !(R_ToplevelExec(check_interrupt_fn, NULL));
+}
 
 int R_curl_callback_progress(SEXP fun,
                              double dltotal, double dlnow,

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,17 +1,9 @@
 #include "curl-common.h"
 #include "utils.h"
 
-int default_callback_progress
-(
-  void *dummy,
-#if LIBCURL_VERSION_NUM >= 0x072000
-  curl_off_t dltotal, curl_off_t dlnow,
-  curl_off_t ultotal, curl_off_t ulnow
-#else
-  double dltotal, double dlnow,
-  double ultotal, double ulnow
-#endif
-)
+int default_callback_progress(void *dummy,
+                              double dltotal, double dlnow,
+                              double ultotal, double ulnow)
 {
   return !(R_ToplevelExec(check_interrupt_fn, NULL));
 }

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,8 +1,8 @@
 #include "curl-common.h"
 #include "utils.h"
 
-int default_callback_progress(void *p, 
-                              double dltotal, double dlnow, 
+int default_callback_progress(void *dummy,
+                              double dltotal, double dlnow,
                               double ultotal, double ulnow)
 {
   return !(R_ToplevelExec(check_interrupt_fn, NULL));

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1,9 +1,17 @@
 #include "curl-common.h"
 #include "utils.h"
 
-int default_callback_progress(void *dummy,
-                              double dltotal, double dlnow,
-                              double ultotal, double ulnow)
+int default_callback_progress
+(
+  void *dummy,
+#if LIBCURL_VERSION_NUM >= 0x072000
+  curl_off_t dltotal, curl_off_t dlnow,
+  curl_off_t ultotal, curl_off_t ulnow
+#else
+  double dltotal, double dlnow,
+  double ultotal, double ulnow
+#endif
+)
 {
   return !(R_ToplevelExec(check_interrupt_fn, NULL));
 }

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -3,5 +3,5 @@ int R_curl_callback_progress(SEXP fun, double dltotal, double dlnow,
 size_t R_curl_callback_read(char *buffer, size_t size, size_t nitems, SEXP fun);
 int R_curl_callback_debug(CURL *handle, curl_infotype type_, char *data,
                           size_t size, SEXP fun);
-int default_callback_progress(void *clientp, double dltotal,
+int default_callback_progress(void *dummy, double dltotal,
                               double dlnow, double ultotal, double ulnow);

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -3,3 +3,5 @@ int R_curl_callback_progress(SEXP fun, double dltotal, double dlnow,
 size_t R_curl_callback_read(char *buffer, size_t size, size_t nitems, SEXP fun);
 int R_curl_callback_debug(CURL *handle, curl_infotype type_, char *data,
                           size_t size, SEXP fun);
+int default_callback_progress(void *clientp, double dltotal,
+                              double dlnow, double ultotal, double ulnow);

--- a/src/handle.c
+++ b/src/handle.c
@@ -142,12 +142,18 @@ SEXP R_handle_setopt(SEXP ptr, SEXP keys, SEXP values){
     if(val == R_NilValue){
       assert(curl_easy_setopt(handle, key, NULL));
     } else if (key == CURLOPT_PROGRESSFUNCTION) {
-      if (TYPEOF(val) != CLOSXP)
-        error("Value for option %s (%d) must be a function.", optname, key);
+      if (TYPEOF(val) != CLOSXP || ! isNull(val))
+        error("Value for option %s (%d) must be a function or NULL.", optname, key);
 
-      assert(curl_easy_setopt(handle, CURLOPT_PROGRESSFUNCTION,
-        (curl_progress_callback) R_curl_callback_progress));
-      assert(curl_easy_setopt(handle, CURLOPT_PROGRESSDATA, val));
+      /* Disable or replace a curl progress callback */
+      if(isNull(val))
+      {
+        assert(curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1L));
+      } else {
+        assert(curl_easy_setopt(handle, CURLOPT_PROGRESSFUNCTION,
+          (curl_progress_callback) R_curl_callback_progress));
+        assert(curl_easy_setopt(handle, CURLOPT_PROGRESSDATA, val));
+      }
     } else if (key == CURLOPT_READFUNCTION) {
       if (TYPEOF(val) != CLOSXP)
         error("Value for option %s (%d) must be a function.", optname, key);

--- a/src/handle.c
+++ b/src/handle.c
@@ -86,9 +86,15 @@ void set_handle_defaults(reference *ref){
   assert(curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L));
 
   /* a default progress callback for signal handling */
+#if LIBCURL_VERSION_NUM >= 0x072000
   assert(curl_easy_setopt(handle, CURLOPT_XFERINFOFUNCTION,
          default_callback_progress));
   assert(curl_easy_setopt(handle, CURLOPT_XFERINFODATA, NULL));
+#else
+  assert(curl_easy_setopt(handle, CURLOPT_PROGRESSFUNCTION,
+         default_callback_progress));
+  assert(curl_easy_setopt(handle, CURLOPT_PROGRESSDATA, NULL));
+#endif
   assert(curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 0L));
 }
 

--- a/src/handle.c
+++ b/src/handle.c
@@ -142,17 +142,15 @@ SEXP R_handle_setopt(SEXP ptr, SEXP keys, SEXP values){
     if(val == R_NilValue){
       assert(curl_easy_setopt(handle, key, NULL));
     } else if (key == CURLOPT_PROGRESSFUNCTION) {
-      if (TYPEOF(val) != CLOSXP || ! isNull(val))
-        error("Value for option %s (%d) must be a function or NULL.", optname, key);
-
       /* Disable or replace a curl progress callback */
-      if(isNull(val))
-      {
+      if(isNull(val)) {
         assert(curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1L));
-      } else {
+      } else if (TYPEOF(val) == CLOSXP) {
         assert(curl_easy_setopt(handle, CURLOPT_PROGRESSFUNCTION,
           (curl_progress_callback) R_curl_callback_progress));
         assert(curl_easy_setopt(handle, CURLOPT_PROGRESSDATA, val));
+      } else {
+        error("Value for option %s (%d) must be a function or NULL.", optname, key);
       }
     } else if (key == CURLOPT_READFUNCTION) {
       if (TYPEOF(val) != CLOSXP)

--- a/src/handle.c
+++ b/src/handle.c
@@ -84,6 +84,12 @@ void set_handle_defaults(reference *ref){
   /* allow all authentication methods */
   assert(curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY));
   assert(curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L));
+
+  /* a default progress callback for signal handling */
+  assert(curl_easy_setopt(handle, CURLOPT_XFERINFOFUNCTION,
+         default_callback_progress));
+  assert(curl_easy_setopt(handle, CURLOPT_XFERINFODATA, NULL));
+  assert(curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 0L));
 }
 
 SEXP R_new_handle(){

--- a/src/handle.c
+++ b/src/handle.c
@@ -86,15 +86,9 @@ void set_handle_defaults(reference *ref){
   assert(curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L));
 
   /* a default progress callback for signal handling */
-#if LIBCURL_VERSION_NUM >= 0x072000
-  assert(curl_easy_setopt(handle, CURLOPT_XFERINFOFUNCTION,
-         default_callback_progress));
-  assert(curl_easy_setopt(handle, CURLOPT_XFERINFODATA, NULL));
-#else
   assert(curl_easy_setopt(handle, CURLOPT_PROGRESSFUNCTION,
          default_callback_progress));
   assert(curl_easy_setopt(handle, CURLOPT_PROGRESSDATA, NULL));
-#endif
   assert(curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 0L));
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,2 @@
+
+void check_interrupt_fn(void *dummy);


### PR DESCRIPTION
OK, 2nd try...

First, thank you for this extremely well-written and useful package.

Unlike the custom R connection `curl` function, the `curl_fetch_*` functions use `curl_easy_perform` without a default progress callback function that can check for interrupts.

One serious consequence, for example, is that almost no `httr` package functions can be interrupted, without manually supplying an R function progress callback and introducing a lot of overhead.

The idea of this PR is to introduce a lightweight default progress function callback that simply calls the existing `check_interrupt_fn` so that all easy_perform transfers are responsive to interrupts. Users remain free to set a custom R progress callback function in the handle, overriding the simple default. One can disable the callback on a handle with:
```r
h = new_handle()
handle_setopt(h, progressfunction=NULL, noprogress=TRUE)
```

## Example
To see an example, at least on Linux systems with the `nc` program installed, follow this procedure:

1. Open a terminal window and run

    ```
    nc -l 9999
    ```

2. Start R either from the command line or RStudio and run

    ```r
    library(curl)
    curl_fetch_memory("http://localhost:9999")
    
    # or, to equivalent effect,
    library(httr)
    GET("http://localhost:9999")
    ```

Now try to interrupt the download with CTRL+C (command-line R) or by pressing the STOP button or ESC (RStudio). The R process will hang. Fortunately, you can back out of this example gracefully by pressing CTRL+C in the terminal window that `nc` is running in (Step 1.).

Now try installing this fork of the `curl` package and repeat the procedure. You should be able to cancel the download.

## Overhead

A quick and dirty test to measure the overhead of the default callback progress
function for bulk data transfers on localhost appears below. We crudely transfer 500MB of
zeros to curl as shown below.

Each `curl_fetch_memory` statement below was preceeded by the following
shell command entered in a separate shell process:
```
dd if=/dev/zero bs=1M count=500 2>/dev/null | nc -l 9999
```

The R session ran two sets of data transfers, with and without the callback
function active, each repeated three times. The 'without the callback function'
experiments mimic the old package behavior (non-interruptable).

```r
R.version
system         x86_64, linux-gnu
version.string R version 3.2.2 (2015-08-14)

# --------------------- without the callback function -----------------
> h = new_handle(); handle_setopt(h, progressfunction=NULL, noprogress=TRUE)
> t1=proc.time();x=curl_fetch_memory("http://localhost:9999");proc.time()-t1
   user  system elapsed
  0.540   1.388   3.188
> rm(x);gc()

> h = new_handle(); handle_setopt(h, progressfunction=NULL, noprogress=TRUE)
> t1=proc.time();x=curl_fetch_memory("http://localhost:9999");proc.time()-t1
   user  system elapsed
  0.612   1.312   3.271
> rm(x); gc()

> h = new_handle(); handle_setopt(h, progressfunction=NULL, noprogress=TRUE)
> t1=proc.time();x=curl_fetch_memory("http://localhost:9999");proc.time()-t1
   user  system elapsed
  0.628   1.328   3.305
> rm(x); gc()


# --- now with the proposed default progress callback function enabled ----
> t1=proc.time();x=curl_fetch_memory("http://localhost:9999");proc.time()-t1
   user  system elapsed
  0.616   1.300   3.205
> rm(x); gc()

> t1=proc.time();x=curl_fetch_memory("http://localhost:9999");proc.time()-t1
   user  system elapsed
  0.560   1.320   3.186
> rm(x);gc()

> t1=proc.time();x=curl_fetch_memory("http://localhost:9999");proc.time()-t1
   user  system elapsed
  0.640   1.276   3.295
```