### PR TITLE
include sys/socket.h on non-win32 which is required for AF_INET/AF_INET6

### DIFF
--- a/src/nslookup.c
+++ b/src/nslookup.c
@@ -6,6 +6,7 @@
 #include <ws2tcpip.h>
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 #else
+#include <sys/socket.h>
 #include <netdb.h>
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
That broke at least OpenBSD 5.9 where neither `netdb.h` nor `arpa/inet.h` include `sys/socket.h`.