### PR TITLE
Better user interruption

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -16,7 +16,7 @@ int R_curl_callback_progress(SEXP fun,
   int ok;
   SEXP res = PROTECT(R_tryEval(call, R_GlobalEnv, &ok));
 
-  if (ok != 0 || pending_interrupt()) {
+  if (ok != 0) {
     UNPROTECT(4);
     return 0;
   }
@@ -38,7 +38,7 @@ size_t R_curl_callback_read(char *buffer, size_t size, size_t nitems, SEXP fun) 
   int ok;
   SEXP res = PROTECT(R_tryEval(call, R_GlobalEnv, &ok));
 
-  if (ok != 0 || pending_interrupt()) {
+  if (ok != 0) {
     UNPROTECT(3);
     return CURL_READFUNC_ABORT;
   }

--- a/src/curl-common.h
+++ b/src/curl-common.h
@@ -29,6 +29,6 @@ void set_form(reference *ref, struct curl_httppost* newform);
 void set_headers(reference *ref, struct curl_slist *newheaders);
 void reset_resheaders(reference *ref);
 void clean_handle(reference *ref);
-int pending_interrupt();
 size_t push_disk(void* contents, size_t sz, size_t nmemb, FILE *ctx);
 size_t append_buffer(void *contents, size_t sz, size_t nmemb, void *ctx);
+CURLcode curl_perform_with_interrupt(CURL *handle);

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -24,7 +24,8 @@ SEXP R_curl_fetch_memory(SEXP url, SEXP ptr){
   curl_easy_setopt(handle, CURLOPT_WRITEDATA, &body);
 
   /* perform blocking request */
-  CURLcode status = curl_easy_perform(handle);
+  //CURLcode status = curl_easy_perform(handle);
+  CURLcode status = curl_perform_with_interrupt(handle);
 
   /* Reset for reuse */
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, NULL);
@@ -72,7 +73,8 @@ SEXP R_curl_fetch_disk(SEXP url, SEXP ptr, SEXP path, SEXP mode){
   curl_easy_setopt(handle, CURLOPT_WRITEDATA, dest);
 
   /* perform blocking request */
-  CURLcode status = curl_easy_perform(handle);
+  //CURLcode status = curl_easy_perform(handle);
+  CURLcode status = curl_perform_with_interrupt(handle);
 
   /* cleanup */
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, NULL);

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -1,0 +1,69 @@
+/* Non-blocking drop-in replacement for curl_easy_perform with support for
+ * R interruptions. Based on: https://curl.haxx.se/libcurl/c/multi-single.html
+ */
+
+#include <Rinternals.h>
+#include <curl/curl.h>
+
+/* Check for interrupt without long jumping */
+void check_interrupt_fn(void *dummy) {
+  R_CheckUserInterrupt();
+}
+
+int pending_interrupt() {
+  return !(R_ToplevelExec(check_interrupt_fn, NULL));
+}
+
+/* Don't call Rf_error() until we remove the handle from the multi handle!
+ */
+CURLcode curl_perform_with_interrupt(CURL *handle){
+  /* start settings */
+  CURLcode status = CURLE_FAILED_INIT;
+  int still_running = 1;
+
+  /* setup multi handle */
+  CURLM *multi_handle = curl_multi_init();
+  if(CURLM_OK != curl_multi_add_handle(multi_handle, handle)){
+    curl_multi_cleanup(multi_handle);
+    return CURLE_FAILED_INIT;
+  }
+
+  /* non blocking downloading */
+  while(still_running) {
+    if(pending_interrupt()){
+      status = CURLE_ABORTED_BY_CALLBACK;
+      break;
+    }
+
+    /* wait for activity, timeout or "nothing" */
+    int numfds;
+    if(curl_multi_wait(multi_handle, NULL, 0, 1000, &numfds) != CURLM_OK)
+      break;
+
+    /* Required by old versions of libcurl */
+    CURLMcode res = CURLM_CALL_MULTI_PERFORM;
+    while(res == CURLM_CALL_MULTI_PERFORM)
+      res = curl_multi_perform(multi_handle, &(still_running));
+
+    /* check for multi errors */
+    if(res != CURLM_OK)
+      break;
+  }
+
+  /* set status if handle has completed. This might be overkill */
+  if(!still_running){
+    int msgq = 0;
+    do {
+      CURLMsg *m = curl_multi_info_read(multi_handle, &msgq);
+      if(m && (m->msg == CURLMSG_DONE)){
+        status = m->data.result;
+        break;
+      }
+    } while (msgq > 0);
+  }
+
+  /* cleanup first */
+  curl_multi_remove_handle(multi_handle, handle);
+  curl_multi_cleanup(multi_handle);
+  return status;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,13 +1,5 @@
 #include "curl-common.h"
 
-void check_interrupt_fn(void *dummy) {
-  R_CheckUserInterrupt();
-}
-
-int pending_interrupt() {
-  return !(R_ToplevelExec(check_interrupt_fn, NULL));
-}
-
 CURL* get_handle(SEXP ptr){
   if(!R_ExternalPtrAddr(ptr))
     error("handle is dead");
@@ -90,14 +82,14 @@ SEXP slist_to_vec(struct curl_slist *slist){
 }
 
 size_t push_disk(void* contents, size_t sz, size_t nmemb, FILE *ctx) {
-  if (pending_interrupt())
-    return 0;
+  //if (pending_interrupt())
+  //  return 0;
   return fwrite(contents, sz, nmemb, ctx);
 }
 
 size_t append_buffer(void *contents, size_t sz, size_t nmemb, void *ctx) {
-  if (pending_interrupt())
-    return 0;
+//if (pending_interrupt())
+  //  return 0;
 
   /* avoids compiler warning on windows */
   size_t realsize = sz * nmemb;


### PR DESCRIPTION
As proposed in https://github.com/jeroenooms/curl/issues/25: catch `SIGINT` via multi-handle rather than in one of the callback functions. 

The `curl_perform_with_interrupt` function is a drop-in replacement for `curl_easy_perform` which returns `CURLE_ABORTED_BY_CALLBACK` when the R user has interrupted.

Need to properly test this on all platforms for side effects and performance regression.