### PR TITLE
Test for keep-alive (#79)

### DIFF
--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -21,6 +21,17 @@ test_that("Cookies", {
   expect_equal(jsonlite::fromJSON(rawToChar(curl_fetch_memory(httpbin("cookies"), handle = h)$content))$cookies$bar, NULL)
 })
 
+test_that("Keep-Alive", {
+  # Connection to httpbin already set in previous tests. Subsequent requests
+  # should reuse the connection.
+  # Capture the verbose curl output to look for the connection reuse message
+  h <- handle_setopt(h, verbose=TRUE,
+    debugfunction=function(type, msg) cat(readBin(msg, character())))
+  req <- capture.output(curl_fetch_memory(httpbin("get"), handle=h))
+  expect_true(any(grepl("Re-using existing connection!", req)))
+  handle_setopt(h, verbose=FALSE)
+})
+
 test_that("Compression and destorying connection", {
   con <- curl(httpbin("deflate"), handle = h)
   expect_equal(jsonlite::fromJSON(readLines(con))$deflate, TRUE)


### PR DESCRIPTION
Here's a simplified test that connections are kept alive following https://github.com/jeroenooms/curl/commit/2184c23132a2ef631996630ac0172b3cbfa9958f. This test fails against previous master (release 2.2) but passes now (https://travis-ci.org/nealrichardson/curl/builds/175340444).