### PR TITLE
Fix busy waiting in curl() open(), closes #84

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -210,6 +210,10 @@ static Rboolean rcurl_open(Rconnection con) {
  /* Wait for first data to arrive. Monitoring a change in status code does not
    suffice in case of http redirects */
   while(req->has_more && !req->has_data) {
+#ifdef HAS_MULTI_WAIT
+    int numfds;
+    massert(curl_multi_wait(req->manager, NULL, 0, 1000, &numfds));
+#endif
     fetchdata(req);
   }
 


### PR DESCRIPTION
A bunch of test cases fail for me, but they also fail before this change, so I guess it is fine. I am not sure how we could test it.